### PR TITLE
Prevent hydration problems

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,13 @@ function omitMatchMediaResult (matchMediaResult) {
 }
 
 function useMedia (query) {
+  var mounted = React.useState(false)
+  var setMounted = mounted[1]
+
+  React.useEffect(function () {
+    setMounted(true)
+  }, [setMounted])
+
   var result = React.useState(function () {
     return omitMatchMediaResult(fallbackMatchMedia(query))
   })
@@ -39,6 +46,10 @@ function useMedia (query) {
     },
     [callback, query]
   )
+
+  if (!mounted[0]) {
+    return null
+  }
 
   return result[0]
 }

--- a/index.js
+++ b/index.js
@@ -28,8 +28,14 @@ function useMedia (query) {
     function () {
       var matchMediaResult = fallbackMatchMedia(query)
       callback(matchMediaResult)
-      matchMediaResult.addListener(callback)
-      return function () { return matchMediaResult.removeListener(callback) }
+      if (matchMediaResult) {
+        matchMediaResult.addEventListener('change', callback)
+      }
+      return function () {
+        if (matchMediaResult) {
+          matchMediaResult.removeEventListener('change', callback)
+        }
+      }
     },
     [callback, query]
   )


### PR DESCRIPTION
While rendering the application, there was a difference between the React tree that was pre-rendered (SSR/SSG) and the React tree that rendered during the first render in the Browser. The first render is called Hydration.

In this package, the difference comes from the use of `window.matchMedia`.

I made the following Sandbox to point out the problem https://codesandbox.io/s/react-18-react-media-hook-hydration-dzgupy?file=/pages/index.js

Resources:
- https://nextjs.org/docs/messages/react-hydration-error
- https://www.joshwcomeau.com/react/the-perils-of-rehydration/